### PR TITLE
Add support for individual blog feeds, OPML, and variable limits

### DIFF
--- a/www/includes/opml-template.php
+++ b/www/includes/opml-template.php
@@ -1,20 +1,20 @@
 <?php
 function escape($input)
 {
-        echo htmlspecialchars($input);
+    echo htmlspecialchars($input);
 }
 function site_url($site)
 {
-        echo preg_replace( '/\/feed$/', '', preg_replace( '/^https?:\/\//', '', $site['URL'] ) );
+    echo preg_replace( '/\/feed$/', '', preg_replace( '/^https?:\/\//', '', $site['URL'] ) );
 }
 ?>
 <?xml version="1.0" encoding="UTF-8"?><opml version="1.0">
 <head>
-        <title>WPCOM subscriptions for <?php escape($_SERVER['PHP_AUTH_USER']) ?></title>
+    <title>WPCOM subscriptions for <?php escape($_SERVER['PHP_AUTH_USER']) ?></title>
 </head>
 <body>
 <?php foreach($followed_sites as $site) { ?>
-        <outline type="rss" title="<?php site_url( $site ); ?>" xmlUrl="<?php echo BASE_URI, '/rss.php?blog=', $site['blog_ID']; ?>" />
+    <outline type="rss" title="<?php site_url( $site ); ?>" xmlUrl="<?php echo BASE_URI, '/rss.php?blog=', $site['blog_ID']; ?>" />
 <?php } ?>
 </body>
 </opml>

--- a/www/includes/opml-template.php
+++ b/www/includes/opml-template.php
@@ -1,0 +1,20 @@
+<?php
+function escape($input)
+{
+        echo htmlspecialchars($input);
+}
+function site_url($site)
+{
+        echo preg_replace( '/\/feed$/', '', preg_replace( '/^https?:\/\//', '', $site['URL'] ) );
+}
+?>
+<?xml version="1.0" encoding="UTF-8"?><opml version="1.0">
+<head>
+        <title>WPCOM subscriptions for <?php escape($_SERVER['PHP_AUTH_USER']) ?></title>
+</head>
+<body>
+<?php foreach($followed_sites as $site) { ?>
+        <outline type="rss" title="<?php site_url( $site ); ?>" xmlUrl="<?php echo BASE_URI, '/rss.php?blog=', $site['blog_ID']; ?>" />
+<?php } ?>
+</body>
+</opml>

--- a/www/rss.php
+++ b/www/rss.php
@@ -32,20 +32,13 @@ function send_unauthorized_response()
 
 function get_followed_sites()
 {
-	$response = request('/read/following/mine');
-
-    $out = [];
-
-    foreach ($response['subscriptions'] as $site) {
-        $out[] = $site['blog_ID'];
-    }
-
-    return $out;
+    return request('/read/following/mine')['subscriptions'];
 }
 
 $me = get_me();
 
 $followed_sites = get_followed_sites();
+$followed_site_ids = array_map(fn($site): int => intval($site['blog_ID']), $followed_sites);
 
 if (isset($_GET['team']) && 'a8c' === $_GET['team']) {
     $path       = 'a8c';
@@ -75,7 +68,7 @@ foreach ($response['posts'] as $post) {
     }
 
     if ($cross_post_site) {
-        if (in_array($cross_post_site, $followed_sites)) {
+        if (in_array($cross_post_site, $followed_site_ids)) {
             continue;
         } else {
             $post_response = request(

--- a/www/rss.php
+++ b/www/rss.php
@@ -42,6 +42,13 @@ $followed_site_ids = array_map(fn($site): int => intval($site['blog_ID']), $foll
 
 if (isset($_GET['team']) && 'a8c' === $_GET['team']) {
     $path       = 'a8c';
+if( 'opml' == $_GET['format'] ) {
+    header('Content-Type: application/xml');
+    header('Content-Disposition: attachment; filename="opml.xml"');
+    require __DIR__ . '/includes/opml-template.php';
+    exit;
+}
+
     $feed_title = 'a8c';
 } else {
     $path       = 'following';

--- a/www/rss.php
+++ b/www/rss.php
@@ -40,8 +40,6 @@ $me = get_me();
 $followed_sites = get_followed_sites();
 $followed_site_ids = array_map(fn($site): int => intval($site['blog_ID']), $followed_sites);
 
-if (isset($_GET['team']) && 'a8c' === $_GET['team']) {
-    $path       = 'a8c';
 if( 'opml' == $_GET['format'] ) {
     header('Content-Type: application/xml');
     header('Content-Disposition: attachment; filename="opml.xml"');
@@ -49,19 +47,27 @@ if( 'opml' == $_GET['format'] ) {
     exit;
 }
 
+if (isset($_GET['blog'])) {
+    $blog       = intval( $_GET['blog'] );
+    $path       = '/sites/' . $blog . '/posts';
+    $feed_title = $blog;
+} else if (isset($_GET['team']) && 'a8c' === $_GET['team']) {
+    $path       = '/read/a8c';
     $feed_title = 'a8c';
 } else {
-    $path       = 'following';
+    $path       = '/read/following';
     $feed_title = 'WordPress.com';
 }
 
-$response = request('/read/' . $path . '?number=20');
+$limit = intval( $_GET['limit'] ?? 20 );
+
+$response = request($path . '?number=' . $limit);
 $posts    = [];
 
-foreach ($response['posts'] as $post) {
-	if ('Auto Draft' === $post['title']) {
-		continue;
-	}
+foreach (($response['posts'] ?? []) as $post) {
+        if ('Auto Draft' === $post['title']) {
+                continue;
+        }
 
     $cross_post_site = false;
     $cross_post_id   = null;

--- a/www/rss.php
+++ b/www/rss.php
@@ -104,5 +104,6 @@ foreach (($response['posts'] ?? []) as $post) {
 }
 
 header('Content-Type: application/rss+xml');
+header('Content-Disposition: attachment; filename="rss.xml"');
 require __DIR__ . '/includes/rss-template.php';
 exit;

--- a/www/rss.php
+++ b/www/rss.php
@@ -92,11 +92,11 @@ foreach (($response['posts'] ?? []) as $post) {
                 )
             );
 
-			if ($post_response && isset($post_response['content'])) {
-				$post['ID']       = $cross_post_id;
-				$post['site_ID']  = $cross_post_site;
-				$post['content'] .= $post_response['content'];
-			}
+                        if ($post_response && isset($post_response['content'])) {
+                                $post['ID']       = $cross_post_id;
+                                $post['site_ID']  = $cross_post_site;
+                                $post['content'] .= $post_response['content'];
+                        }
         }
     }
 

--- a/www/rss.php
+++ b/www/rss.php
@@ -30,19 +30,6 @@ function send_unauthorized_response()
     exit;
 }
 
-function get_sites()
-{
-	$response = request('/me/sites');
-
-    $out = [];
-
-    foreach ($response['sites'] as $site) {
-        $out[] = $site['ID'];
-    }
-
-    return $out;
-}
-
 function get_followed_sites()
 {
 	$response = request('/read/following/mine');
@@ -57,8 +44,6 @@ function get_followed_sites()
 }
 
 $me = get_me();
-
-$sites = [];
 
 $followed_sites = get_followed_sites();
 
@@ -115,4 +100,3 @@ foreach ($response['posts'] as $post) {
 header('Content-Type: application/rss+xml');
 require __DIR__ . '/includes/rss-template.php';
 exit;
-

--- a/www/start.php
+++ b/www/start.php
@@ -52,6 +52,13 @@ $escaper = new Escaper();
             </td>
         </tr>
         <tr>
+            <th scope="row">More URL options</th>
+            <td>
+                <code>?limit=20</code> - how many posts to fetch; default 20<br />
+                <code>?blog=12345</code> - returns posts only from site 12345; get the URLs from OPML
+            </td>
+        </tr>
+        <tr>
             <th scope="row">Username</th>
             <td><?php echo $escaper->escapeHtml($db_user['username']);?></td>
         </tr>

--- a/www/start.php
+++ b/www/start.php
@@ -45,6 +45,10 @@ $escaper = new Escaper();
                 <h2>a8c</h2>
                 <a href="<?php echo BASE_URI;?>/rss.php?team=a8c"><?php echo BASE_URI;?>/rss.php?team=a8c</a>
                 <?php endif;?>
+                <br />
+                <br />
+                <h2>OPML of individual feeds</h2>
+                <a href="<?php echo BASE_URI;?>/rss.php?format=opml"><?php echo BASE_URI;?>/rss.php?format=opml</a>
             </td>
         </tr>
         <tr>

--- a/www/start.php
+++ b/www/start.php
@@ -70,5 +70,5 @@ $escaper = new Escaper();
     </tbody>
 </table>
 
-<?php require __DIR__  . '/includes/help.php';?>
+<?php require __DIR__ . '/includes/help.php';?>
 <?php require __DIR__ . '/includes/footer.php';?>


### PR DESCRIPTION
## Description

I'd like to be able to:

- Specify how many posts to return by adding `?limit=30` to my feed URLs (retaining a default of 20 where not specified)
- Subscribe to individual blogs by passing `?blog=12345` (where `12345` is the blog_ID of a blog I follow) to my feed URL
- Download an OPML file containing a list of all such individual-blog feeds
- Have the default filename that's recommended when manually downloading a feed be appropriate (e.g. `rss.xml` rather than `rss.php`), to make testing easier

This PR does all the above, plus it removes some never-used code (`get_sites()` etc.) and standardises indentation (at four spaces, never tabs) in the files it touches.

## Testing

1. Test all core functionality
2. Use the OPML link to download an OPML file (suitable for importing into many RSS readers) listing all your RSS URLs for individual blogs
3. Try some individual blogs using the URLs from the OPML file (note that this only works for WPCOM-hosted blogs, not Jetpack-linked blogs you "follow" - these have their own independent feed URLs and we should be proxying them as this isn't necessary for publicly-accessible URLs; however it's plenty good enough for A8c P2s etc. which seems to be the intended audience and works for WPCOM-hosted blogs too)
4. Whether using an individual blog or a full (following) or team (a8c) list, append `?limit=3` and see that only 3 posts are returned, for example

(if it makes testing easier, I've got a copy of this running at https://wpcom-via-rss.fox.q-t-a.uk/)